### PR TITLE
refector : 모든 Entity의 부모 identifier 적용

### DIFF
--- a/src/main/java/com/example/sns_project/application/CommentService.java
+++ b/src/main/java/com/example/sns_project/application/CommentService.java
@@ -56,6 +56,7 @@ public class CommentService {
                 .id(savedComment.getId())
                 .comment(savedComment.getContent())
                 .author(savedComment.getAuthor())
+                .lastModifiedAt(savedComment.getLastModifiedAt())
                 .build();
     }
 

--- a/src/main/java/com/example/sns_project/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/sns_project/config/jwt/JwtProcess.java
@@ -20,7 +20,7 @@ public class JwtProcess {
         String jwtToken = JWT.create()
                 .withSubject("wanted")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.EXPIRATION_TIM))
-                .withClaim("id", loginUser.getUser().getId().getUserId())
+                .withClaim("id", loginUser.getUser().getId().getId())
                 .withClaim("email", loginUser.getUser().getEmail())
                 .withClaim("role", loginUser.getUser().getUserRole().name())
                 .sign(Algorithm.HMAC512(secretKey));

--- a/src/main/java/com/example/sns_project/domain/Identifier.java
+++ b/src/main/java/com/example/sns_project/domain/Identifier.java
@@ -1,0 +1,14 @@
+package com.example.sns_project.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+
+public abstract class Identifier implements Serializable {
+
+    public final String id;
+
+    public Identifier() {
+        id = String.valueOf(UUID.randomUUID());
+    }
+}

--- a/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
+++ b/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
@@ -1,45 +1,27 @@
 package com.example.sns_project.domain.comment.entity;
 
+import com.example.sns_project.domain.Identifier;
 import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.UUID;
 
+@EqualsAndHashCode
 @Getter
 @Embeddable
-public class CommentId implements Serializable {
+public class CommentId extends Identifier {
+    private final String id;
 
-    // todo commentId를 생성할 다른방법이 있지 않을까?
-    public static Long COMMENT_SEQUENCE = 0L;
-    private Long CommentId;
+    public CommentId() {
+        id = super.id;
+    }
 
     /**
      * for Controller Constructor
      */
-    public CommentId(final String commentId) {
-        CommentId = Long.valueOf(commentId);
-    }
-
-    public CommentId() {
-        CommentId = COMMENT_SEQUENCE++;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        final CommentId commentId = (CommentId) o;
-
-        return Objects.equals(CommentId, commentId.CommentId);
-    }
-
-    @Override
-    public int hashCode() {
-        return CommentId != null ? CommentId.hashCode() : 0;
+    public CommentId(final String id) {
+        this.id = id;
     }
 }

--- a/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
@@ -1,36 +1,26 @@
 package com.example.sns_project.domain.post.entity;
 
+import com.example.sns_project.domain.Identifier;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.util.Objects;
+import java.util.UUID;
 
+@EqualsAndHashCode
 @Getter
 @Embeddable
-public class PostId {
-    public static Long POST_SEQUENCE = 0L;
-    private Long postId;
-
-    public PostId(final String postId) {
-        this.postId = Long.valueOf(postId);
-    }
+public class PostId extends Identifier {
+    private final String id;
 
     public PostId() {
-        this.postId = POST_SEQUENCE++;
+        this.id = super.id;
     }
 
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        final PostId postId1 = (PostId) o;
-
-        return Objects.equals(postId, postId1.postId);
-    }
-
-    @Override
-    public int hashCode() {
-        return postId != null ? postId.hashCode() : 0;
+    /**
+     * for Controller Constructor
+     */
+    public PostId(final String id) {
+        this.id = id;
     }
 }

--- a/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
+++ b/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
@@ -1,37 +1,27 @@
 package com.example.sns_project.domain.user.entity;
 
+import com.example.sns_project.domain.Identifier;
 import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.io.Serializable;
-import java.util.Objects;
 import java.util.UUID;
 
+@EqualsAndHashCode
 @Getter
 @Embeddable
-public class UserId implements Serializable {
+public class UserId extends Identifier {
+    private String id;
 
-    private String UserId;
     public UserId() {
-        UserId = String.valueOf(UUID.randomUUID());
+        id = super.id;
     }
 
+    /**
+     * for Controller Constructor
+     */
     public UserId(String uuid) {
-        UserId = uuid;
-    }
-
-    @Override
-    public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-
-        final com.example.sns_project.domain.user.entity.UserId userid = (com.example.sns_project.domain.user.entity.UserId) o;
-
-        return Objects.equals(UserId, userid.UserId);
-    }
-
-    @Override
-    public int hashCode() {
-        return UserId != null ? UserId.hashCode() : 0;
+        id = uuid;
     }
 }

--- a/src/test/java/com/example/sns_project/controller/PostControllerTest.java
+++ b/src/test/java/com/example/sns_project/controller/PostControllerTest.java
@@ -82,7 +82,7 @@ class PostControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.id.postId").value(postId.getPostId()))
+                .andExpect(jsonPath("$.data.id.postId").value(postId.getId()))
                 .andExpect(jsonPath("$.data.title").value("제목"))
                 .andExpect(jsonPath("$.data.content").value("내용"))
                 .andDo(print())


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [X] 리펙토링 : 모든 Entity의 부모 identifier 적용
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 작업 내역

Entity의 id를 Identifier클래스를 통해 공통으로 빼내어 예상가능한 코드를 작성하였습니다. 

Idenfifyer 클래스를 만들어 모든 Entity가 상속받게 하였습니다.
Entity가 생성될때 부모인 Indetifer가 먼저 생성되어 생성자에서 UUID를 발급하고,
Entity는 Identiier의 UUID를 자신의 id로 사용합니다.

이제 모든 Entity는 UUID를 id로 사용한다고 예상할 수 있습니다.

### 어떤 부분에 리뷰어가 집중하면 좋을까요?

모든 Entity에서 Identifier를 상속받아 UUID를 사용하는것이 이번 refectoring의 핵심입니다! 

<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
