### PR TITLE
refector : 연관관계 맵핑 -> Id 참조

### DIFF
--- a/src/main/java/com/example/sns_project/application/CommentService.java
+++ b/src/main/java/com/example/sns_project/application/CommentService.java
@@ -44,7 +44,6 @@ public class CommentService {
                 .orElseThrow(PostNotFound::new);
 
         final Comment comment = Comment.builder()
-                .userId(user.getUserId())
                 .author(user.getEmail())
                 .content(commentCreate.content())
                 .postId(post.getPostId())
@@ -89,8 +88,10 @@ public class CommentService {
     public String edit(final CommentId commentId, final CommentEdit commentEdit, final UserId userId) {
         var comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFound::new);
+        var user = userRepository.findById(userId)
+                .orElseThrow(UserNotFound::new);
 
-        if (!comment.isSameUser(userId)){
+        if (!comment.isSameUser(user.getEmail())){
             throw new UserNotMatch();
         }
 
@@ -102,8 +103,10 @@ public class CommentService {
     public String delete(final CommentId commentId, final UserId userId) {
         var comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFound::new);
+        var user = userRepository.findById(userId)
+                .orElseThrow(UserNotFound::new);
 
-        if (!comment.isSameUser(userId)){
+        if (!comment.isSameUser(user.getEmail())){
             throw new UserNotMatch();
         }
 

--- a/src/main/java/com/example/sns_project/application/CommentService.java
+++ b/src/main/java/com/example/sns_project/application/CommentService.java
@@ -52,7 +52,7 @@ public class CommentService {
         final Comment savedComment = commentRepository.save(comment);
 
         return CommentResponse.builder()
-                .id(savedComment.getCommentId())
+                .commentId(savedComment.getCommentId())
                 .comment(savedComment.getContent())
                 .author(savedComment.getAuthor())
                 .lastModifiedAt(savedComment.getLastModifiedAt())
@@ -65,7 +65,7 @@ public class CommentService {
                 .orElseThrow(CommentNotFound::new);
 
         return CommentResponse.builder()
-                .id(comment.getCommentId())
+                .commentId(comment.getCommentId())
                 .comment(comment.getContent())
                 .author(comment.getAuthor())
                 .build();

--- a/src/main/java/com/example/sns_project/application/CommentService.java
+++ b/src/main/java/com/example/sns_project/application/CommentService.java
@@ -17,7 +17,6 @@ import com.example.sns_project.domain.user.exception.UserNotMatch;
 import com.example.sns_project.infra.jpa.CommentRepositoryImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,15 +44,16 @@ public class CommentService {
                 .orElseThrow(PostNotFound::new);
 
         final Comment comment = Comment.builder()
+                .userId(user.getUserId())
                 .author(user.getEmail())
                 .content(commentCreate.content())
-                .post(post)
+                .postId(post.getPostId())
                 .build();
 
         final Comment savedComment = commentRepository.save(comment);
 
         return CommentResponse.builder()
-                .id(savedComment.getId())
+                .id(savedComment.getCommentId())
                 .comment(savedComment.getContent())
                 .author(savedComment.getAuthor())
                 .lastModifiedAt(savedComment.getLastModifiedAt())
@@ -66,7 +66,7 @@ public class CommentService {
                 .orElseThrow(CommentNotFound::new);
 
         return CommentResponse.builder()
-                .id(comment.getId())
+                .id(comment.getCommentId())
                 .comment(comment.getContent())
                 .author(comment.getAuthor())
                 .build();

--- a/src/main/java/com/example/sns_project/application/PostService.java
+++ b/src/main/java/com/example/sns_project/application/PostService.java
@@ -40,10 +40,11 @@ public class PostService {
 
         var post = postRepository.save(postNotValid);
 
-        post.addUser(user);
+        post.addUser(user.getUserId());
+        user.addPost(post.getPostId());
 
         return PostResponse.builder()
-                .id(post.getId())
+                .id(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();
@@ -54,7 +55,7 @@ public class PostService {
         final Post post = postRepository.findById(postId).orElseThrow(PostNotFound::new);
 
         return PostResponse.builder()
-                .id(post.getId())
+                .id(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();

--- a/src/main/java/com/example/sns_project/application/PostService.java
+++ b/src/main/java/com/example/sns_project/application/PostService.java
@@ -52,7 +52,8 @@ public class PostService {
 
     @Transactional
     public PostResponse get(final PostId postId) {
-        final Post post = postRepository.findById(postId).orElseThrow(PostNotFound::new);
+        final Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFound::new);
 
         return PostResponse.builder()
                 .id(post.getPostId())

--- a/src/main/java/com/example/sns_project/application/PostService.java
+++ b/src/main/java/com/example/sns_project/application/PostService.java
@@ -44,7 +44,7 @@ public class PostService {
         user.addPost(post.getPostId());
 
         return PostResponse.builder()
-                .id(post.getPostId())
+                .postId(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();
@@ -56,7 +56,7 @@ public class PostService {
                 .orElseThrow(PostNotFound::new);
 
         return PostResponse.builder()
-                .id(post.getPostId())
+                .postId(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .build();

--- a/src/main/java/com/example/sns_project/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/sns_project/config/jwt/JwtAuthenticationFilter.java
@@ -64,7 +64,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         response.addHeader(JwtVO.HEADER, jwtToken);
 
         LoginRespDto loginRespDto = LoginRespDto.builder()
-                .id(user.getId())
+                .id(user.getUserId())
                 .email(user.getEmail())
                 .build();
 

--- a/src/main/java/com/example/sns_project/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/sns_project/config/jwt/JwtProcess.java
@@ -20,7 +20,7 @@ public class JwtProcess {
         String jwtToken = JWT.create()
                 .withSubject("wanted")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.EXPIRATION_TIM))
-                .withClaim("id", loginUser.getUser().getId().getId())
+                .withClaim("id", loginUser.getUser().getUserId().getUserId())
                 .withClaim("email", loginUser.getUser().getEmail())
                 .withClaim("role", loginUser.getUser().getUserRole().name())
                 .sign(Algorithm.HMAC512(secretKey));
@@ -36,7 +36,7 @@ public class JwtProcess {
         String role = decodedJWT.getClaim("role").asString();
 
         User user = User.builder()
-                .id(new UserId(id))
+                .userId(new UserId(id))
                 .email(email)
                 .userRole(UserRole.valueOf(role))
                 .build();

--- a/src/main/java/com/example/sns_project/config/jwt/JwtProcess.java
+++ b/src/main/java/com/example/sns_project/config/jwt/JwtProcess.java
@@ -20,7 +20,7 @@ public class JwtProcess {
         String jwtToken = JWT.create()
                 .withSubject("wanted")
                 .withExpiresAt(new Date(System.currentTimeMillis() + JwtVO.EXPIRATION_TIM))
-                .withClaim("id", loginUser.getUser().getUserId().getUserId())
+                .withClaim("id", loginUser.getUser().getUserId().getId())
                 .withClaim("email", loginUser.getUser().getEmail())
                 .withClaim("role", loginUser.getUser().getUserRole().name())
                 .sign(Algorithm.HMAC512(secretKey));

--- a/src/main/java/com/example/sns_project/domain/Identifier.java
+++ b/src/main/java/com/example/sns_project/domain/Identifier.java
@@ -1,11 +1,23 @@
 package com.example.sns_project.domain;
 
+import lombok.Getter;
+
 import java.io.Serializable;
 import java.util.UUID;
 
-
+@Getter
 public abstract class Identifier implements Serializable {
-    public String makeIdentifier() {
-        return String.valueOf(UUID.randomUUID());
+    private final String id;
+
+    protected Identifier() {
+        this.id = String.valueOf(UUID.randomUUID());
     }
+
+    /**
+     * for Controller Constructor
+     */
+    protected Identifier(String uuid) {
+        this.id = uuid;
+    }
+
 }

--- a/src/main/java/com/example/sns_project/domain/Identifier.java
+++ b/src/main/java/com/example/sns_project/domain/Identifier.java
@@ -1,11 +1,13 @@
 package com.example.sns_project.domain;
 
+import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
 import java.io.Serializable;
 import java.util.UUID;
 
 @Getter
+@MappedSuperclass
 public abstract class Identifier implements Serializable {
     private final String id;
 

--- a/src/main/java/com/example/sns_project/domain/Identifier.java
+++ b/src/main/java/com/example/sns_project/domain/Identifier.java
@@ -5,10 +5,7 @@ import java.util.UUID;
 
 
 public abstract class Identifier implements Serializable {
-
-    public final String id;
-
-    public Identifier() {
-        id = String.valueOf(UUID.randomUUID());
+    public String makeIdentifier() {
+        return String.valueOf(UUID.randomUUID());
     }
 }

--- a/src/main/java/com/example/sns_project/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/example/sns_project/domain/comment/dto/CommentResponse.java
@@ -6,14 +6,14 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 
-public record CommentResponse(CommentId id, String comment, String author, LocalDateTime lastModifiedAt) {
+public record CommentResponse(CommentId commentId, String comment, String author, LocalDateTime lastModifiedAt) {
 
     public CommentResponse(Comment comment) {
         this(comment.getCommentId(), comment.getContent(), comment.getAuthor(), comment.getLastModifiedAt());
     }
     @Builder
-    public CommentResponse(final CommentId id, final String comment, final String author, final LocalDateTime lastModifiedAt) {
-        this.id = id;
+    public CommentResponse(final CommentId commentId, final String comment, final String author, final LocalDateTime lastModifiedAt) {
+        this.commentId = commentId;
         this.comment = comment;
         this.author = author;
         this.lastModifiedAt = lastModifiedAt;

--- a/src/main/java/com/example/sns_project/domain/comment/dto/CommentResponse.java
+++ b/src/main/java/com/example/sns_project/domain/comment/dto/CommentResponse.java
@@ -2,7 +2,6 @@ package com.example.sns_project.domain.comment.dto;
 
 import com.example.sns_project.domain.comment.entity.Comment;
 import com.example.sns_project.domain.comment.entity.CommentId;
-import com.example.sns_project.domain.post.entity.Post;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -10,7 +9,7 @@ import java.time.LocalDateTime;
 public record CommentResponse(CommentId id, String comment, String author, LocalDateTime lastModifiedAt) {
 
     public CommentResponse(Comment comment) {
-        this(comment.getId(), comment.getContent(), comment.getAuthor(), comment.getLastModifiedAt());
+        this(comment.getCommentId(), comment.getContent(), comment.getAuthor(), comment.getLastModifiedAt());
     }
     @Builder
     public CommentResponse(final CommentId id, final String comment, final String author, final LocalDateTime lastModifiedAt) {

--- a/src/main/java/com/example/sns_project/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/sns_project/domain/comment/entity/Comment.java
@@ -23,7 +23,6 @@ public class Comment {
     @EmbeddedId
     @Column(name = "commentId")
     private CommentId commentId;
-    private UserId userId;
     private String author;
     private String content;
     private PostId postId;
@@ -33,12 +32,11 @@ public class Comment {
     private LocalDateTime lastModifiedAt;
 
     @Builder
-    public Comment(CommentId commentId, final UserId userId, final String content, final String author, final PostId postId) {
+    public Comment(CommentId commentId, final String content, final String author, final PostId postId) {
         if (commentId == null) {
             commentId = new CommentId();
         }
         this.commentId = commentId;
-        this.userId = userId;
         this.content = content;
         this.author = author;
         this.postId = postId;
@@ -61,9 +59,9 @@ public class Comment {
         }
     }
 
-    public boolean isSameUser(final UserId userId) {
+    public boolean isSameUser(final String userEmail) {
         isValid();
-        return this.userId.equals(userId);
+        return this.author.equals(userEmail);
     }
 
     public void editComment(final String comment) {

--- a/src/main/java/com/example/sns_project/domain/comment/entity/Comment.java
+++ b/src/main/java/com/example/sns_project/domain/comment/entity/Comment.java
@@ -1,8 +1,8 @@
 package com.example.sns_project.domain.comment.entity;
 
 import com.example.sns_project.config.util.BanWords;
-import com.example.sns_project.domain.post.entity.Post;
 import com.example.sns_project.config.exception.InvalidRequest;
+import com.example.sns_project.domain.post.entity.PostId;
 import com.example.sns_project.domain.user.entity.UserId;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -20,33 +20,28 @@ import java.util.Arrays;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Comment {
-
     @EmbeddedId
-    private CommentId id;
-
+    @Column(name = "commentId")
+    private CommentId commentId;
+    private UserId userId;
     private String author;
-
     private String content;
-
-    @ManyToOne
-    @JoinColumn
-    private Post post;
-
+    private PostId postId;
     @CreatedDate
     private LocalDateTime createdAt;
-
     @LastModifiedDate
     private LocalDateTime lastModifiedAt;
 
     @Builder
-    public Comment(CommentId id, final String content, final String author, final Post post) {
-        if (id == null) {
-            id = new CommentId();
+    public Comment(CommentId commentId, final UserId userId, final String content, final String author, final PostId postId) {
+        if (commentId == null) {
+            commentId = new CommentId();
         }
-        this.id = id;
+        this.commentId = commentId;
+        this.userId = userId;
         this.content = content;
         this.author = author;
-        this.post = post;
+        this.postId = postId;
         this.createdAt = LocalDateTime.now();
         this.lastModifiedAt = LocalDateTime.now();
         isValid();
@@ -68,7 +63,7 @@ public class Comment {
 
     public boolean isSameUser(final UserId userId) {
         isValid();
-        return this.post.getUser().getId().equals(userId);
+        return this.userId.equals(userId);
     }
 
     public void editComment(final String comment) {

--- a/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
+++ b/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
@@ -12,17 +12,12 @@ import lombok.Getter;
 @Embeddable
 @AttributeOverride(name = "id", column = @Column(name = "commentId"))
 public class CommentId extends Identifier {
-    private final String id;
-
-    public CommentId() {
-        id = super.getId();
-    }
+    public CommentId() {}
 
     /**
      * for Controller Constructor
      */
     public CommentId(final String uuid) {
         super(uuid);
-        id = super.getId();
     }
 }

--- a/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
+++ b/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
@@ -1,6 +1,8 @@
 package com.example.sns_project.domain.comment.entity;
 
 import com.example.sns_project.domain.Identifier;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -8,17 +10,19 @@ import lombok.Getter;
 @EqualsAndHashCode
 @Getter
 @Embeddable
+@AttributeOverride(name = "id", column = @Column(name = "commentId"))
 public class CommentId extends Identifier {
-    private final String commentId;
+    private final String id;
 
     public CommentId() {
-        commentId = super.makeIdentifier();
+        id = super.getId();
     }
 
     /**
      * for Controller Constructor
      */
     public CommentId(final String uuid) {
-        this.commentId = uuid;
+        super(uuid);
+        id = super.getId();
     }
 }

--- a/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
+++ b/src/main/java/com/example/sns_project/domain/comment/entity/CommentId.java
@@ -5,23 +5,20 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.io.Serializable;
-import java.util.UUID;
-
 @EqualsAndHashCode
 @Getter
 @Embeddable
 public class CommentId extends Identifier {
-    private final String id;
+    private final String commentId;
 
     public CommentId() {
-        id = super.id;
+        commentId = super.makeIdentifier();
     }
 
     /**
      * for Controller Constructor
      */
-    public CommentId(final String id) {
-        this.id = id;
+    public CommentId(final String uuid) {
+        this.commentId = uuid;
     }
 }

--- a/src/main/java/com/example/sns_project/domain/post/dto/PostCreate.java
+++ b/src/main/java/com/example/sns_project/domain/post/dto/PostCreate.java
@@ -22,7 +22,7 @@ public record PostCreate(
 
     public Post toEntity() {
         return Post.builder()
-                .id(new PostId())
+                .postId(new PostId())
                 .title(this.title)
                 .content(this.content)
                 .build();

--- a/src/main/java/com/example/sns_project/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/example/sns_project/domain/post/dto/PostResponse.java
@@ -5,14 +5,14 @@ import com.example.sns_project.domain.post.entity.PostId;
 import lombok.Builder;
 
 
-public record PostResponse (PostId id, String title, String content){
+public record PostResponse (PostId postId, String title, String content){
     public PostResponse(Post post) {
         this(post.getPostId(), post.getTitle(), post.getContent());
     }
 
     @Builder
-    public PostResponse(final PostId id, final String title, final String content) {
-        this.id = id;
+    public PostResponse(final PostId postId, final String title, final String content) {
+        this.postId = postId;
         this.title = title;
         this.content = content;
     }

--- a/src/main/java/com/example/sns_project/domain/post/dto/PostResponse.java
+++ b/src/main/java/com/example/sns_project/domain/post/dto/PostResponse.java
@@ -6,9 +6,8 @@ import lombok.Builder;
 
 
 public record PostResponse (PostId id, String title, String content){
-
     public PostResponse(Post post) {
-        this(post.getId(), post.getTitle(), post.getContent());
+        this(post.getPostId(), post.getTitle(), post.getContent());
     }
 
     @Builder

--- a/src/main/java/com/example/sns_project/domain/post/entity/Post.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/Post.java
@@ -1,8 +1,8 @@
 package com.example.sns_project.domain.post.entity;
 
 import com.example.sns_project.config.util.BanWords;
-import com.example.sns_project.domain.comment.entity.Comment;
 import com.example.sns_project.config.exception.InvalidRequest;
+import com.example.sns_project.domain.comment.entity.CommentId;
 import com.example.sns_project.domain.user.entity.User;
 import com.example.sns_project.domain.user.entity.UserId;
 import com.example.sns_project.domain.user.exception.UserNotMatch;
@@ -16,39 +16,33 @@ import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post {
-
     @EmbeddedId
-    private PostId id;
+    @Column(name = "postId")
+    private PostId postId;
     private String content;
     private String title;
-    @ManyToOne
-    @JoinColumn
-    private User user;
-
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "post")
-    private List<Comment> comments;
-
+    private CommentId commentId;
+    private UserId userId;
     @CreatedDate
     private LocalDateTime createdAt;
-
     @LastModifiedDate
     private LocalDateTime lastModifiedAt;
 
     @Builder
-    public Post(PostId id, final String content, final String title, User user) {
-        if (id == null) {
-            id = new PostId();
+    public Post(PostId postId, final String content, final String title, UserId userId, CommentId commentId) {
+        if (postId == null) {
+            postId = new PostId();
         }
-        this.id = id;
+        this.postId = postId;
         this.content = content;
         this.title = title;
-        this.user = user;
+        this.userId = userId;
+        this.commentId = commentId;
         this.createdAt = LocalDateTime.now();
         this.lastModifiedAt = LocalDateTime.now();
     }
@@ -60,12 +54,12 @@ public class Post {
         this.lastModifiedAt = LocalDateTime.now();
     }
 
-    public void addUser(final User user) {
-        this.user = user;
+    public void addUser(final UserId userId) {
+        this.userId = userId;
     }
 
     public void isSameUser(final UserId userId) {
-        if (this.user == null || !this.user.getId().equals(userId) ) {
+        if (this.userId == null || !this.userId.equals(userId) ) {
             throw new UserNotMatch();
         }
     }

--- a/src/main/java/com/example/sns_project/domain/post/entity/Post.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.example.sns_project.domain.post.entity;
 import com.example.sns_project.config.util.BanWords;
 import com.example.sns_project.config.exception.InvalidRequest;
 import com.example.sns_project.domain.comment.entity.CommentId;
+import com.example.sns_project.domain.user.entity.User;
 import com.example.sns_project.domain.user.entity.UserId;
 import com.example.sns_project.domain.user.exception.UserNotMatch;
 import jakarta.persistence.*;
@@ -26,21 +27,21 @@ public class Post {
     private String content;
     private String title;
     private CommentId commentId;
-    private UserId author;
+    private UserId userId;
     @CreatedDate
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime lastModifiedAt;
 
     @Builder
-    public Post(PostId postId, final String content, final String title, UserId author, CommentId commentId) {
+    public Post(PostId postId, final String content, final String title, UserId userId, CommentId commentId) {
         if (postId == null) {
             postId = new PostId();
         }
         this.postId = postId;
         this.content = content;
         this.title = title;
-        this.author = author;
+        this.userId = userId;
         this.commentId = commentId;
         this.createdAt = LocalDateTime.now();
         this.lastModifiedAt = LocalDateTime.now();
@@ -54,11 +55,11 @@ public class Post {
     }
 
     public void addUser(final UserId userId) {
-        this.author = userId;
+        this.userId = userId;
     }
 
     public void isSameUser(final UserId userId) {
-        if (this.author == null || !this.author.equals(userId) ) {
+        if (this.userId == null || !this.userId.equals(userId) ) {
             throw new UserNotMatch();
         }
     }

--- a/src/main/java/com/example/sns_project/domain/post/entity/Post.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/Post.java
@@ -3,7 +3,6 @@ package com.example.sns_project.domain.post.entity;
 import com.example.sns_project.config.util.BanWords;
 import com.example.sns_project.config.exception.InvalidRequest;
 import com.example.sns_project.domain.comment.entity.CommentId;
-import com.example.sns_project.domain.user.entity.User;
 import com.example.sns_project.domain.user.entity.UserId;
 import com.example.sns_project.domain.user.exception.UserNotMatch;
 import jakarta.persistence.*;
@@ -27,21 +26,21 @@ public class Post {
     private String content;
     private String title;
     private CommentId commentId;
-    private UserId userId;
+    private UserId author;
     @CreatedDate
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime lastModifiedAt;
 
     @Builder
-    public Post(PostId postId, final String content, final String title, UserId userId, CommentId commentId) {
+    public Post(PostId postId, final String content, final String title, UserId author, CommentId commentId) {
         if (postId == null) {
             postId = new PostId();
         }
         this.postId = postId;
         this.content = content;
         this.title = title;
-        this.userId = userId;
+        this.author = author;
         this.commentId = commentId;
         this.createdAt = LocalDateTime.now();
         this.lastModifiedAt = LocalDateTime.now();
@@ -55,11 +54,11 @@ public class Post {
     }
 
     public void addUser(final UserId userId) {
-        this.userId = userId;
+        this.author = userId;
     }
 
     public void isSameUser(final UserId userId) {
-        if (this.userId == null || !this.userId.equals(userId) ) {
+        if (this.author == null || !this.author.equals(userId) ) {
             throw new UserNotMatch();
         }
     }

--- a/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
@@ -12,17 +12,12 @@ import lombok.Getter;
 @Embeddable
 @AttributeOverride(name = "id", column = @Column(name = "postId"))
 public class PostId extends Identifier {
-    private final String id;
-
-    public PostId() {
-        id = super.getId();
-    }
+    public PostId() {}
 
     /**
      * for Controller Constructor
      */
     public PostId(final String uuid) {
         super(uuid);
-        id = super.getId();
     }
 }

--- a/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
@@ -5,22 +5,20 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.util.UUID;
-
 @EqualsAndHashCode
 @Getter
 @Embeddable
 public class PostId extends Identifier {
-    private final String id;
+    private final String postId;
 
     public PostId() {
-        this.id = super.id;
+        this.postId = super.makeIdentifier();
     }
 
     /**
      * for Controller Constructor
      */
-    public PostId(final String id) {
-        this.id = id;
+    public PostId(final String uuid) {
+        this.postId = uuid;
     }
 }

--- a/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
+++ b/src/main/java/com/example/sns_project/domain/post/entity/PostId.java
@@ -1,6 +1,8 @@
 package com.example.sns_project.domain.post.entity;
 
 import com.example.sns_project.domain.Identifier;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -8,17 +10,19 @@ import lombok.Getter;
 @EqualsAndHashCode
 @Getter
 @Embeddable
+@AttributeOverride(name = "id", column = @Column(name = "postId"))
 public class PostId extends Identifier {
-    private final String postId;
+    private final String id;
 
     public PostId() {
-        this.postId = super.makeIdentifier();
+        id = super.getId();
     }
 
     /**
      * for Controller Constructor
      */
     public PostId(final String uuid) {
-        this.postId = uuid;
+        super(uuid);
+        id = super.getId();
     }
 }

--- a/src/main/java/com/example/sns_project/domain/user/entity/User.java
+++ b/src/main/java/com/example/sns_project/domain/user/entity/User.java
@@ -1,11 +1,14 @@
 package com.example.sns_project.domain.user.entity;
 
 import com.example.sns_project.domain.post.entity.Post;
+import com.example.sns_project.domain.post.entity.PostId;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,40 +17,37 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User{
-
     @EmbeddedId
-    private UserId id;
-
+    @Column(name = "userId")
+    private UserId userId;
     private String name;
-
     private String email;
-
     private String password;
-
     private UserRole userRole;
-
-    @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
-    private List<Post> posts;
-
+    @CreatedDate
     private LocalDateTime createdAt;
-
+    @LastModifiedDate
     private LocalDateTime lastModifiedAt;
-
-    public UserId getId() {
-        return id;
+    private PostId postId;
+    public UserId getUserId() {
+        return userId;
     }
 
     @Builder
-    public User(UserId id, final String name, final String email, final String password, final  UserRole userRole) {
-        if (id == null) {
-            id = new UserId();
+    public User(UserId userId, final String name, final String email, final String password, final  UserRole userRole) {
+        if (userId == null) {
+            userId = new UserId();
         }
-        this.id = id;
+        this.userId = userId;
         this.name = name;
         this.email = email;
         this.password = password;
         this.userRole = userRole;
         this.createdAt = LocalDateTime.now();
         this.lastModifiedAt = LocalDateTime.now();
+    }
+
+    public void addPost(PostId postId) {
+        this.postId = postId;
     }
 }

--- a/src/main/java/com/example/sns_project/domain/user/entity/User.java
+++ b/src/main/java/com/example/sns_project/domain/user/entity/User.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.UniqueElements;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 
@@ -21,6 +22,7 @@ public class User{
     @Column(name = "userId")
     private UserId userId;
     private String name;
+    @Column(unique = true)
     private String email;
     private String password;
     private UserRole userRole;

--- a/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
+++ b/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
@@ -12,17 +12,12 @@ import lombok.Getter;
 @Embeddable
 @AttributeOverride(name = "id", column = @Column(name = "userId"))
 public class UserId extends Identifier {
-    private final String id;
-
-    public UserId() {
-        id = super.getId();
-    }
+    public UserId() {}
 
     /**
      * for Controller Constructor
      */
     public UserId(String uuid) {
         super(uuid);
-        id = super.getId();
     }
 }

--- a/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
+++ b/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
@@ -5,23 +5,20 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-import java.io.Serializable;
-import java.util.UUID;
-
 @EqualsAndHashCode
 @Getter
 @Embeddable
 public class UserId extends Identifier {
-    private String id;
+    private String userId;
 
     public UserId() {
-        id = super.id;
+        userId = super.makeIdentifier();
     }
 
     /**
      * for Controller Constructor
      */
     public UserId(String uuid) {
-        id = uuid;
+        userId = uuid;
     }
 }

--- a/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
+++ b/src/main/java/com/example/sns_project/domain/user/entity/UserId.java
@@ -1,6 +1,8 @@
 package com.example.sns_project.domain.user.entity;
 
 import com.example.sns_project.domain.Identifier;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -8,17 +10,19 @@ import lombok.Getter;
 @EqualsAndHashCode
 @Getter
 @Embeddable
+@AttributeOverride(name = "id", column = @Column(name = "userId"))
 public class UserId extends Identifier {
-    private String userId;
+    private final String id;
 
     public UserId() {
-        userId = super.makeIdentifier();
+        id = super.getId();
     }
 
     /**
      * for Controller Constructor
      */
     public UserId(String uuid) {
-        userId = uuid;
+        super(uuid);
+        id = super.getId();
     }
 }

--- a/src/main/java/com/example/sns_project/interfaces/CommentController.java
+++ b/src/main/java/com/example/sns_project/interfaces/CommentController.java
@@ -30,7 +30,7 @@ public class CommentController {
     public ResponseEntity<ResponseDto<CommentResponse>> comment(@ModelAttribute final PostId postId, @RequestBody @Valid CommentCreate commentCreate, BindingResult bindingResult
             , @AuthenticationPrincipal LoginUser loginUser)
     {
-        final CommentResponse comment = commentService.comment(postId, commentCreate, loginUser.getUser().getId());
+        final CommentResponse comment = commentService.comment(postId, commentCreate, loginUser.getUser().getUserId());
 
         return ResponseEntity.ok(ResponseDto.success(comment));
     }
@@ -52,13 +52,13 @@ public class CommentController {
 
     @PostMapping("/auth/comments/{commentId}")
     public ResponseEntity<ResponseDto<String>> edit(@ModelAttribute CommentId commentId, @RequestBody CommentEdit commentEdit, @AuthenticationPrincipal LoginUser loginUser) {
-        final String success = commentService.edit(commentId, commentEdit, loginUser.getUser().getId());
+        final String success = commentService.edit(commentId, commentEdit, loginUser.getUser().getUserId());
         return ResponseEntity.ok(ResponseDto.success(success));
     }
 
     @DeleteMapping("/auth/comments/{commentId}")
     public ResponseEntity<ResponseDto<String>> delete(@ModelAttribute CommentId commentId, @AuthenticationPrincipal LoginUser loginUser) {
-        final String success = commentService.delete(commentId, loginUser.getUser().getId());
+        final String success = commentService.delete(commentId, loginUser.getUser().getUserId());
         return ResponseEntity.ok(ResponseDto.success(success));
     }
 }

--- a/src/main/java/com/example/sns_project/interfaces/PostController.java
+++ b/src/main/java/com/example/sns_project/interfaces/PostController.java
@@ -4,7 +4,6 @@ import com.example.sns_project.application.PostService;
 import com.example.sns_project.domain.post.dto.PostCreate;
 import com.example.sns_project.domain.post.dto.PostEdit;
 import com.example.sns_project.domain.post.dto.PostResponse;
-import com.example.sns_project.domain.post.dto.PostSearch;
 import com.example.sns_project.config.auth.LoginUser;
 import com.example.sns_project.config.util.ResponseDto;
 import com.example.sns_project.domain.post.entity.PostId;
@@ -33,7 +32,7 @@ public class PostController {
             , @AuthenticationPrincipal LoginUser loginUser)
     {
 
-        final PostResponse write = postService.write(postCreate, loginUser.getUser().getId());
+        final PostResponse write = postService.write(postCreate, loginUser.getUser().getUserId());
         return ResponseEntity.ok(ResponseDto.success(write));
     }
 
@@ -55,14 +54,14 @@ public class PostController {
     public ResponseEntity<ResponseDto<String>> edit(@ModelAttribute PostId postId, @RequestBody PostEdit postEdit
             , @AuthenticationPrincipal LoginUser loginUser)
     {
-        postService.edit(postId, postEdit, loginUser.getUser().getId());
+        postService.edit(postId, postEdit, loginUser.getUser().getUserId());
 
         return ResponseEntity.ok(ResponseDto.success());
     }
 
     @DeleteMapping("/auth/posts/{postId}")
     public ResponseEntity<ResponseDto<String>> delete(@ModelAttribute PostId postId, @AuthenticationPrincipal LoginUser loginUser) {
-        postService.delete(postId, loginUser.getUser().getId());
+        postService.delete(postId, loginUser.getUser().getUserId());
 
         return ResponseEntity.ok(ResponseDto.success());
     }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -439,13 +439,13 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/styles/github.min.css">
 </head>
 <body class="book toc2 toc-left">
-<div id="header">
+<div postId="header">
 <h1>게시판 API</h1>
 <div class="details">
-<span id="revnumber">version 0.0.1-SNAPSHOT</span>
+<span postId="revnumber">version 0.0.1-SNAPSHOT</span>
 </div>
-<div id="toc" class="toc2">
-<div id="toctitle">Table of Contents</div>
+<div postId="toc" class="toc2">
+<div postId="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
 <li><a href="#_글_단건조회">글 단건조회</a>
 <ul class="sectlevel2">
@@ -462,12 +462,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 </ul>
 </div>
 </div>
-<div id="content">
+<div postId="content">
 <div class="sect1">
-<h2 id="_글_단건조회"><a class="link" href="#_글_단건조회">글 단건조회</a></h2>
+<h2 postId="_글_단건조회"><a class="link" href="#_글_단건조회">글 단건조회</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_요청"><a class="link" href="#_요청">요청</a></h3>
+<h3 postId="_요청"><a class="link" href="#_요청">요청</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /posts/1 HTTP/1.1
@@ -496,7 +496,7 @@ Host: api.board.com</code></pre>
 </table>
 </div>
 <div class="sect2">
-<h3 id="_응답"><a class="link" href="#_응답">응답</a></h3>
+<h3 postId="_응답"><a class="link" href="#_응답">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -510,7 +510,7 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 84
 
-{"message":"SUCCESS","data":{"id":{"postId":1},"title":"제목","content":"내용"}}</code></pre>
+{"message":"SUCCESS","data":{"postId":{"postId":1},"title":"제목","content":"내용"}}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -533,7 +533,7 @@ Content-Length: 84
 <td class="tableblock halign-left valign-top"><p class="tableblock">SUCCESS</p></td>
 </tr>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id.postId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.postId.postId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">1</p></td>
 </tr>
@@ -553,10 +553,10 @@ Content-Length: 84
 </div>
 </div>
 <div class="sect1">
-<h2 id="_글_작성"><a class="link" href="#_글_작성">글 작성</a></h2>
+<h2 postId="_글_작성"><a class="link" href="#_글_작성">글 작성</a></h2>
 <div class="sectionbody">
 <div class="sect2">
-<h3 id="_요청_2"><a class="link" href="#_요청_2">요청</a></h3>
+<h3 postId="_요청_2"><a class="link" href="#_요청_2">요청</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /auth/posts HTTP/1.1
@@ -604,7 +604,7 @@ Host: api.board.com
 </table>
 </div>
 <div class="sect2">
-<h3 id="_응답_2"><a class="link" href="#_응답_2">응답</a></h3>
+<h3 postId="_응답_2"><a class="link" href="#_응답_2">응답</a></h3>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -618,15 +618,15 @@ Strict-Transport-Security: max-age=31536000 ; includeSubDomains
 X-Frame-Options: DENY
 Content-Length: 84
 
-{"message":"SUCCESS","data":{"id":{"postId":0},"title":"제목","content":"내용"}}</code></pre>
+{"message":"SUCCESS","data":{"postId":{"postId":0},"title":"제목","content":"내용"}}</code></pre>
 </div>
 </div>
 </div>
 </div>
 </div>
 </div>
-<div id="footer">
-<div id="footer-text">
+<div postId="footer">
+<div postId="footer-text">
 Version 0.0.1-SNAPSHOT<br>
 Last updated 2023-08-07 18:59:11 +0900
 </div>

--- a/src/test/java/com/example/sns_project/controller/PostControllerTest.java
+++ b/src/test/java/com/example/sns_project/controller/PostControllerTest.java
@@ -82,7 +82,7 @@ class PostControllerTest {
                 )
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("SUCCESS"))
-                .andExpect(jsonPath("$.data.id.postId").value(postId.getId()))
+                .andExpect(jsonPath("$.data.id.postId").value(postId.getPostId()))
                 .andExpect(jsonPath("$.data.title").value("제목"))
                 .andExpect(jsonPath("$.data.content").value("내용"))
                 .andDo(print())

--- a/src/test/java/com/example/sns_project/service/PostServiceTest.java
+++ b/src/test/java/com/example/sns_project/service/PostServiceTest.java
@@ -124,7 +124,7 @@ class PostServiceTest {
         given(postRepository.findById(any())).willReturn(Optional.ofNullable(response));
 
         //when
-        final PostResponse postResponse = postService.get(response.getId());
+        final PostResponse postResponse = postService.get(response.getPostId());
 
         //then
         assertThat(postResponse).isNotNull();


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [ ] 신규 기능 추가 :
- [ ] 버그 수정 :
- [X] 리펙토링 : 연관관계 맵핑 -> Id 참조
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 애그리거트간의 경계를 명확히 하고 물리적 연결을 제거하여 복잡도를 낮추기 위해 객체간 Id를 참조하게 변경하였습니다.
- Identifier에서 id를 필드로 갖고있으면 상속받은 엔티티에서 필드로 사용할때 컬럼명이 엔티티간 중복이 되기때문에 사용하기 어려워 Identifier에서는 UUID를 발급하는 용도로 변경하였습니다.

### 어떤 부분에 리뷰어가 집중하면 좋을까요?

#### 연관관계 맵핑 변경
JPA의 연관관계 맵핑을 사용했던 코드를 Id를 참조로 변경하였습니다.
애그리거트간의 접근이 직접적으로 불가능하여 경계가 명확해 졌습니다.

엔티티간에 변경된 코드를 보시면 리뷰하시는데 도움이 될것입니다.
 
#### Identifier 역할
Identifier에서 id를 각 엔티티마다 공통으로 사용하게되면 Colum명이 Entity간에 중복되어 에러가 발생하였습니다.
따라서 id는 Entity마다 따로 사용하고 식별자를 Identifier에서 발급받도록 설계하였습니다.

<!-- 좋은 pr 체크리스트 -->
<!-- 
- 무슨 이유로 코드를 변경했는지
- 어떤 위험이나 장애가 발견되었는지
- 어떤 부분에 리뷰어가 집중하면 좋을지
- 관련 스크린샷
- 테스트 계획 또는 완료 사항 -->
